### PR TITLE
ci: add publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,59 @@
+name: Publish Release from Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release Tag (e.g., v3.1.1 or v3.1.1-beta.1)'
+        required: true
+        default: 'v3.1.1'
+      workflow_run_id:
+        description: 'Workflow Run ID (from build-package.yml)'
+        required: true
+      release_notes:
+        description: 'Additional Release Notes (optional)'
+        required: false
+        default: ''
+
+jobs:
+  publish:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Download All Artifacts from Build Run
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          run_id: ${{ inputs.workflow_run_id }}
+          name: andromodem-all-packages
+          path: downloaded
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: List Downloaded Artifacts
+        run: |
+          echo "📦 Downloaded artifacts:"
+          ls -lhR downloaded/
+
+      - name: Create Release and Upload Assets
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.tag_name }}
+          body: |
+            ${{ inputs.release_notes }}
+          files: downloaded/**/*
+          draft: false
+          prerelease: ${{ contains(inputs.tag_name, '-dev') || contains(inputs.tag_name, '-beta') || contains(inputs.tag_name, '-alpha') || contains(inputs.tag_name, '-rc') }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "✅ Release ${{ inputs.tag_name }} published successfully!"
+          echo "🔗 View release: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.tag_name }}"


### PR DESCRIPTION
- Add workflow to publish releases from build artifacts
- Support manual release creation with workflow_run_id
- Auto-generate release notes
- Support prerelease detection (beta, alpha, rc, dev)